### PR TITLE
chores: use meetup graphql endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "postcss": "^8.2.10",
     "postcss-cli": "^8.3.1",
     "postcss-import": "^14.0.1",
-    "tailwindcss": "^2.1.1"
+    "tailwindcss": "^2.1.1",
+    "moment": "^2.29.1"
   },
   "browserslist": [
     "last 1 version",

--- a/scripts/fetch-events/constants.js
+++ b/scripts/fetch-events/constants.js
@@ -1,13 +1,45 @@
 const path = require("path");
 
-/**
- * @see https://www.meetup.com/meetup_api/docs/:urlname/events/#list
- */
-const EVENTS_URL =
-  "https://api.meetup.com/Blockchain-Societe-Nantes/events?fields=featured_photo&status=past,upcoming&page=100&desc=true";
 const EVENT_PAGES_PATH = path.join(__dirname, "../../content/fr/events");
 
+const MEETUP_ENDPOINT_GRAPHQL = "https://api.meetup.com/gql";
+const MEETUP_FETCH_EVENTS_GRAPHQL_QUERY = `
+query {
+  groupByUrlname (urlname:"Blockchain-Societe") {
+        upcomingEvents(input:{first:100}) {
+          edges {
+              node{
+                  title,
+                  shortUrl,
+                  description,
+                  dateTime,
+                  duration,
+                  venue { name, address, city },
+                  topics{ edges{ node{ name } } },
+                  imageUrl,
+              }
+          }
+      },
+      pastEvents(input:{first:100}) {
+          edges{
+              node{
+                  title,
+                  shortUrl,
+                  description,
+                  dateTime,
+                  duration,
+                  venue { name, address, city },
+                  topics{ edges{ node{ name } } },
+                  imageUrl,
+              }
+          }
+      },
+  }
+}
+`;
+
 module.exports = {
-  EVENTS_URL,
   EVENT_PAGES_PATH,
+  MEETUP_ENDPOINT_GRAPHQL,
+  MEETUP_FETCH_EVENTS_GRAPHQL_QUERY,
 };

--- a/scripts/fetch-events/index.js
+++ b/scripts/fetch-events/index.js
@@ -1,17 +1,16 @@
-const { EVENTS_URL } = require("./constants");
-const { fetch, buildEventPages } = require("./utils");
+const { fetch, buildEventPages, formatEvent } = require("./utils");
 
 const fetchEventsAsync = new Promise(async (res, rej) => {
-  console.log(`1️⃣...... Fetching events from ENDPOINT ${EVENTS_URL}`);
-  const response = await fetch(EVENTS_URL).catch(rej);
+  console.log(`1️⃣...... Fetching events`);
+  const response = await fetch().catch(rej);
   res(response);
 })
-
-  .then((response) => {
-    console.log("2️⃣...... Formating events");
-    const json = JSON.parse(response);
+  .then((events) => {
+    return events.map(formatEvent);
+  })
+  .then((events) => {
     console.log("3️⃣...... Create events pages");
-    buildEventPages(json);
+    buildEventPages(events);
   })
   .then(() => console.log("🟢 Event fetching is DONE"))
   .catch((error) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1333,6 +1333,11 @@ modern-normalize@^1.1.0:
   resolved "https://registry.yarnpkg.com/modern-normalize/-/modern-normalize-1.1.0.tgz#da8e80140d9221426bd4f725c6e11283d34f90b7"
   integrity sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 nanoid@^3.1.30:
   version "3.1.30"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"


### PR DESCRIPTION
## Nouveautés :

- plus de risque de casser le mécanisme de récupération des évènements (API REST meetup dépréciée cf #104 )
- on peut récupérer les topics meetup pour les affecter comme tags dans nos évènements

## changements : 

- ajout de moment.js dans les dev dependencies pour pouvoir lire le nouveau formation "duration" (ISO ISO_8601)
- l'api retourne par défaut l'image du groupe si aucune image n'est défini pour l'évènement.
- le lien vers la page meetup est un lien court forgé par meetup et retourné par l'API

## régressions :

- pas d'image haute qualité (ou pas encore trouvée)
- pas de formatage de la description (autre que markdown). Avant l'API retournait la description formatée en HTML, maintenant c'est la description brute qui est retournée.
- la récupération du lien de l'image est en "beta" donc peut casser à tout moment. Impossible de trouver un autre lien via l'api autrement que de la forger à la main en partant du principe que le nommage est fixe (`676x380.webp`) et ne change pas en fonction de la source.

close #104 