### PR TITLE
feat: add the RSS feed in <head>

### DIFF
--- a/themes/custom-blist/layouts/partials/head.html
+++ b/themes/custom-blist/layouts/partials/head.html
@@ -52,6 +52,10 @@
     ></script>
   {{ end }}
 
+  {{ range .AlternativeOutputFormats -}}
+    {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
+  {{ end -}}
+
   {{ template "_internal/opengraph.html" . }}
   {{ template "_internal/twitter_cards.html" . }}
   {{ template "_internal/schema.html" . }}

--- a/themes/custom-blist/layouts/partials/homepage/social.html
+++ b/themes/custom-blist/layouts/partials/homepage/social.html
@@ -1,23 +1,11 @@
 <section id="socials" class="{{ .Site.Params.ascentColor }} dark:bg-black-400">
   <div
-    class="
-      container
-      px-6
-      py-12
-      mx-auto
-      max-w-5xl
-      flex flex-row flex-wrap
-      gap-8
-      items-center
-      justify-center
-    "
+    class="container px-6 py-12 mx-auto max-w-5xl flex flex-row flex-wrap gap-8 items-center justify-center"
   >
     <div class="max-w-md flex flex-col">
       <div class="flex flex-col items-center mb-10">
-        {{ partial "components/section-title"
-        (dict
-        "title" (i18n "homeSocialTitle")
-        "anchor" "socials" ) }}
+        {{ partial "components/section-title" (dict "title" (i18n
+        "homeSocialTitle") "anchor" "socials" ) }}
         <div class="rounded bg-black-900 dark:bg-white h-2 w-16 mt-3"></div>
       </div>
       <p class="opacity-60 text-center">{{ i18n "homeSocialDescription" }}</p>

--- a/themes/custom-blist/layouts/partials/homepage/social.html
+++ b/themes/custom-blist/layouts/partials/homepage/social.html
@@ -35,30 +35,29 @@
           />
         </svg>
         <div class="text-gray-400">Twitter</div>
-
-        {{ end }} {{ with .Site.Params.social.youtube }}
-        <a
-          href="{{.}}"
-          target="_blank"
-          rel="noopener"
-          aria-label="YouTube"
-          class="social-card"
-        >
-          <svg
-            class="text-red-500 dark:text-white"
-            xmlns="http://www.w3.org/2000/svg"
-            width="50"
-            height="50"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-          >
-            <path
-              d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"
-            />
-          </svg>
-          <div class="text-gray-400">Youtube</div>
-        </a></a
+      </a>
+      {{ end }} {{ with .Site.Params.social.youtube }}
+      <a
+        href="{{.}}"
+        target="_blank"
+        rel="noopener"
+        aria-label="YouTube"
+        class="social-card"
       >
+        <svg
+          class="text-red-500 dark:text-white"
+          xmlns="http://www.w3.org/2000/svg"
+          width="50"
+          height="50"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path
+            d="M19.615 3.184c-3.604-.246-11.631-.245-15.23 0-3.897.266-4.356 2.62-4.385 8.816.029 6.185.484 8.549 4.385 8.816 3.6.245 11.626.246 15.23 0 3.897-.266 4.356-2.62 4.385-8.816-.029-6.185-.484-8.549-4.385-8.816zm-10.615 12.816v-8l8 3.993-8 4.007z"
+          />
+        </svg>
+        <div class="text-gray-400">Youtube</div>
+      </a>
       {{ end }} {{ with .Site.Params.social.facebook }}
       <a
         href="{{.}}"


### PR DESCRIPTION
Même proposition d'implem que pour le thème upstream: https://github.com/apvarun/blist-hugo-theme/pull/29

:gift: Correction du flux HTML non valide à cause d'une balise `</a>` mal placée de toutes les pages qui affichent les réseaux sociaux

Fix #91 

# Test

- Chercher le tag `<link rel="alternate" type="application/rss+xml" href="https://deploy-preview-107--blockchainetsociete.netlify.app/index.xml" title="Blockchain et Société">`